### PR TITLE
Hotfix 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var port = process.env.PORT || 8000,
 http.createServer(function (req, res) {
   var apiPath = '/api/v1';
   var reqUrl = req.url.startsWith(apiPath) ? req.url.substring(apiPath.length) : req.url;
+    console.log(proxyURL, reqUrl, new URL(proxyURL, reqUrl));
   var r = request(new URL(proxyURL, reqUrl).toString());
 
   // Add CORS Headers

--- a/index.js
+++ b/index.js
@@ -10,8 +10,10 @@ var port = process.env.PORT || 8000,
 
 http.createServer(function (req, res) {
   var hostname = url.parse(req.headers.referer || '').hostname || '';
-	if (hostname.endsWith('.fandom.com') || hostname.endsWith('.wikia.org')) {
-		var apiPath = '/api/v1';
+  
+  console.log(hostname);
+  if (hostname.endsWith('.fandom.com') || hostname.endsWith('.wikia.org')) {
+    var apiPath = '/api/v1';
     var reqUrl = req.url.startsWith(apiPath) ? req.url : apiPath + req.url;
     var r = request(new URL(proxyURL, reqUrl).toString());
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var port = process.env.PORT || 8000,
 http.createServer(function (req, res) {
   var apiPath = '/api/v1';
   var reqUrl = req.url.startsWith(apiPath) ? req.url : apiPath + req.url;
-    console.log(proxyURL, reqUrl);
+    console.log(reqUrl, proxyURL);
   var r = request(new URL(proxyURL, reqUrl).toString());
 
   // Add CORS Headers

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var port = process.env.PORT || 8000,
 
 http.createServer(function (req, res) {
   var apiPath = '/api/v1';
-  var reqUrl = req.url.startsWith(apiPath) ? req.url.substring(apiPath.length) : req.url;
+  var reqUrl = req.url.startsWith(apiPath) ? req.url : apiPath + req.url;
     console.log(proxyURL, reqUrl);
   var r = request(new URL(proxyURL, reqUrl).toString());
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ http.createServer(function (req, res) {
   if (hostname.endsWith('.fandom.com') || hostname.endsWith('.wikia.org')) {
     var apiPath = '/api/v1';
     var reqUrl = req.url.startsWith(apiPath) ? req.url : apiPath + req.url;
-    var r = request(proxyURL + reqUrl);
+    var r = request(new URL(reqUrl, proxyURL));
 
     // Add CORS Headers
     r.on('response', function(_r) {

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ http.createServer(function (req, res) {
     
     // Return empty JSON data
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.write({});
+    res.write('{}');
     res.end();
     
   }

--- a/index.js
+++ b/index.js
@@ -11,10 +11,10 @@ var port = process.env.PORT || 8000,
 http.createServer(function (req, res) {
   var hostname = url.parse(req.headers.referer || '').hostname || '';
   
-  console.log(hostname.endsWith('.fandom.com') || hostname.endsWith('.wikia.org'));
-  if (hostname.endsWith('.fandom.com') || hostname.endsWith('.wikia.org')) {
-    var apiPath = '/api/v1';
-    var reqUrl = req.url.startsWith(apiPath) ? req.url : apiPath + req.url;
+  var apiPath = '/api/v1',
+      reqUrl = req.url.startsWith(apiPath) ? req.url : apiPath + req.url;
+  
+  if ((hostname.endsWith('.fandom.com') || hostname.endsWith('.wikia.org')) && reqUrl.length > apiPath.length + 1) {
     var r = request(new URL(reqUrl, proxyURL).toString());
 
     // Add CORS Headers

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var port = process.env.PORT || 8000,
 http.createServer(function (req, res) {
   var hostname = url.parse(req.headers.referer || '').hostname || '';
   
-  console.log(hostname);
+  console.log(hostname.endsWith('.fandom.com') || hostname.endsWith('.wikia.org'));
   if (hostname.endsWith('.fandom.com') || hostname.endsWith('.wikia.org')) {
     var apiPath = '/api/v1';
     var reqUrl = req.url.startsWith(apiPath) ? req.url : apiPath + req.url;

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ http.createServer(function (req, res) {
   if (hostname.endsWith('.fandom.com') || hostname.endsWith('.wikia.org')) {
     var apiPath = '/api/v1';
     var reqUrl = req.url.startsWith(apiPath) ? req.url : apiPath + req.url;
-    var r = request(new URL(proxyURL, reqUrl).toString());
+    var r = request(proxyURL + reqUrl);
 
     // Add CORS Headers
     r.on('response', function(_r) {

--- a/index.js
+++ b/index.js
@@ -26,11 +26,11 @@ http.createServer(function (req, res) {
     req.pipe(r).pipe(res);
     
   } else {
-
-		// Return empty JSON data
-		res.writeHead(200, { 'Content-Type': 'application/json' });
-		res.write({});
-		res.end();
+    
+    // Return empty JSON data
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.write({});
+    res.end();
     
   }
 }).listen(port);

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var port = process.env.PORT || 8000,
 http.createServer(function (req, res) {
   var apiPath = '/api/v1';
   var reqUrl = req.url.startsWith(apiPath) ? req.url.substring(apiPath.length) : req.url;
-  var r = request(url.resolve(proxyURL, reqUrl));
+  var r = request(new URL(proxyURL, reqUrl).toString());
 
   // Add CORS Headers
   r.on('response', function(_r) {

--- a/index.js
+++ b/index.js
@@ -9,20 +9,30 @@ var port = process.env.PORT || 8000,
     allowHeaders = process.env.ALLOW_HEADERS || 'X-Requested-With'
 
 http.createServer(function (req, res) {
-  var apiPath = '/api/v1';
-  var reqUrl = req.url.startsWith(apiPath) ? req.url : apiPath + req.url;
-    console.log(reqUrl, proxyURL);
-  var r = request(new URL(proxyURL, reqUrl).toString());
+  var hostname = url.parse(req.headers.referer || '').hostname || '';
+	if (hostname.endsWith('.fandom.com') || hostname.endsWith('.wikia.org')) {
+		var apiPath = '/api/v1';
+    var reqUrl = req.url.startsWith(apiPath) ? req.url : apiPath + req.url;
+    var r = request(new URL(proxyURL, reqUrl).toString());
 
-  // Add CORS Headers
-  r.on('response', function(_r) {
-    _r.headers['Access-Control-Allow-Origin'] = allowOrigin;
-    _r.headers['Access-Control-Allow-Methods'] = allowMethods;
-    _r.headers['Access-Control-Allow-Headers'] = allowHeaders;
-  });
+    // Add CORS Headers
+    r.on('response', function(_r) {
+      _r.headers['Access-Control-Allow-Origin'] = allowOrigin;
+      _r.headers['Access-Control-Allow-Methods'] = allowMethods;
+      _r.headers['Access-Control-Allow-Headers'] = allowHeaders;
+    });
 
-  // Stream the response
-  req.pipe(r).pipe(res);
+    // Stream the response
+    req.pipe(r).pipe(res);
+    
+  } else {
+
+		// Return empty JSON data
+		res.writeHead(200, { 'Content-Type': 'application/json' });
+		res.write({});
+		res.end();
+    
+  }
 }).listen(port);
 
 console.log('Proxying ' + proxyURL + ' on port ' + port);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,9 @@ var port = process.env.PORT || 8000,
     allowHeaders = process.env.ALLOW_HEADERS || 'X-Requested-With'
 
 http.createServer(function (req, res) {
-  var r = request(url.resolve(proxyURL, req.url));
+  var apiPath = '/api/v1';
+  var reqUrl = req.url.startsWith(apiPath) ? req.url.substring(apiPath.length) : req.url;
+  var r = request(url.resolve(proxyURL, reqUrl));
 
   // Add CORS Headers
   r.on('response', function(_r) {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ http.createServer(function (req, res) {
   if (hostname.endsWith('.fandom.com') || hostname.endsWith('.wikia.org')) {
     var apiPath = '/api/v1';
     var reqUrl = req.url.startsWith(apiPath) ? req.url : apiPath + req.url;
-    var r = request(new URL(reqUrl, proxyURL));
+    var r = request(new URL(reqUrl, proxyURL).toString());
 
     // Add CORS Headers
     r.on('response', function(_r) {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var port = process.env.PORT || 8000,
 http.createServer(function (req, res) {
   var apiPath = '/api/v1';
   var reqUrl = req.url.startsWith(apiPath) ? req.url.substring(apiPath.length) : req.url;
-    console.log(proxyURL, reqUrl, new URL(proxyURL, reqUrl));
+    console.log(proxyURL, reqUrl);
   var r = request(new URL(proxyURL, reqUrl).toString());
 
   // Add CORS Headers


### PR DESCRIPTION
Not providing a path returns an empty object. Querying api/v1 with no endpoint from an external site rejects the request with a CORS error.

This should stop AVG from incorrectly identifying railwam.herokuapp.com as a phishing site.

TODO: Consider better return values